### PR TITLE
Update jira.py

### DIFF
--- a/jira.py
+++ b/jira.py
@@ -145,8 +145,7 @@ class Jira(BotPlugin):
         jira = self.jira_connect
 
         try:
-            issue = jira.issue(ticket)
-            issue.update(fields={'assignee': {'name':user}})
+            jira.assign_issue(assignee=user, issue=ticket)
             response = 'Reassigned {} to {}'.format(ticket, user)
         except JIRAError:
             response = 'Unable to reassign {} to {}'.format(ticket, user)


### PR DESCRIPTION
changing from update field, to directly using the assign user function in the jira plugin. I had permission issues on some of my projects when using the field update, but those issues were resolved by directly calling the assign_issue function. 